### PR TITLE
Make type conversions explicit

### DIFF
--- a/examples/corona.cpp
+++ b/examples/corona.cpp
@@ -14,8 +14,8 @@ namespace karcst = kariba::constants;
 
 int main() {
 
-    int nel = 100;      // array size for particle distributions
-    int nfreq = 100;    // array size for frequency arrays
+    size_t nel = 100;      // array size for particle distributions
+    size_t nfreq = 100;    // array size for frequency arrays
 
     // Input parameters:
     double Mbh;

--- a/examples/examples.hpp
+++ b/examples/examples.hpp
@@ -21,20 +21,20 @@
 #include <gsl/gsl_sf_bessel.h>
 #include <gsl/gsl_spline.h>
 
-void plot_write(int size, const std::vector<double> &en, const std::vector<double> &lum,
+void plot_write(size_t size, const std::vector<double> &en, const std::vector<double> &lum,
                 const std::string &path, double redshift);
-void plot_write(int size, const std::vector<double> &p, const std::vector<double> &g,
+void plot_write(size_t size, const std::vector<double> &p, const std::vector<double> &g,
                 const std::vector<double> &pdens, const std::vector<double> &gdens,
                 const std::string &path);
 
-void sum_zones(int size_in, int size_out, std::vector<double> &input_en,
+void sum_zones(size_t size_in, size_t size_out, std::vector<double> &input_en,
                std::vector<double> &input_lum, std::vector<double> &en, std::vector<double> &lum);
-void sum_ext(int size_in, int size_out, const std::vector<double> &input_en,
+void sum_ext(size_t size_in, size_t size_out, const std::vector<double> &input_en,
              const std::vector<double> &input_lum, std::vector<double> &en,
              std::vector<double> &lum);
-double integrate_lum(int size, double numin, double numax, const std::vector<double> &input_en,
+double integrate_lum(size_t size, double numin, double numax, const std::vector<double> &input_en,
                      const std::vector<double> &input_lum);
-double photon_index(int size, double numin, double numax, const std::vector<double> &input_en,
+double photon_index(size_t size, double numin, double numax, const std::vector<double> &input_en,
                     const std::vector<double> &input_lum);
 
 void clean_file(const std::string &path, bool check);

--- a/examples/model/bhjet.cpp
+++ b/examples/model/bhjet.cpp
@@ -156,8 +156,8 @@ void jetmain(std::vector<double> &ear, size_t ne, std::vector<double> &param,
     compar3 = param[23];
     compsw = param[24];
     velsw = param[25];
-    infosw = param[26];
-    EBLsw = param[27];
+    infosw = static_cast<int>(param[26]);
+    EBLsw = static_cast<int>(param[27]);
     zmin = 2. * Rg;
 
     if (infosw >= 1) {
@@ -547,7 +547,7 @@ void jetmain(std::vector<double> &ear, size_t ne, std::vector<double> &param,
             syn_max = 50. * pow(gmax, 2.) * karcst::charg * zone.bfield /
                       (2. * karcst::pi * karcst::emgm * karcst::cee);
         }
-        nsyn = (size_t) (int(log10(syn_max) - log10(syn_min)) * syn_res);
+        nsyn = (size_t) (log10(syn_max) - log10(syn_min)) * syn_res;
         std::vector<double> syn_en(nsyn, 0.0);
         std::vector<double> syn_lum(nsyn, 0.0);
         kariba::Cyclosyn Syncro(nsyn);
@@ -555,7 +555,7 @@ void jetmain(std::vector<double> &ear, size_t ne, std::vector<double> &param,
 
         com_min = 0.1 * Syncro.nu_syn();
         com_max = ear[ne - 1] / karcst::hkev;
-        ncom = (size_t) (int(log10(com_max) - log10(com_min)) * com_res);
+        ncom = (size_t) (log10(com_max) - log10(com_min)) * com_res;
         std::vector<double> com_en(ncom, 0.0);
         std::vector<double> com_lum(ncom, 0.0);
         kariba::Compton InvCompton(ncom, nsyn);

--- a/examples/model/bhjet.hpp
+++ b/examples/model/bhjet.hpp
@@ -54,8 +54,8 @@ typedef struct jet_enpars {
 
 // Structure including distance grid calculations
 typedef struct grid_pars {
-    int nz;         // total number of zones
-    int cut;        // zone counter after which grid switched to logarithmic spacing
+    size_t nz;      // total number of zones
+    size_t cut;     // zone counter after which grid switched to logarithmic spacing
     double zcut;    // distance at which grid switched to log spacing
 } grid_pars;
 
@@ -99,7 +99,7 @@ void plot_write(size_t size, const std::vector<double> &p, const std::vector<dou
                 const std::vector<double> &pdens, const std::vector<double> &gdens,
                 const std::string &path);
 
-bool Compton_check(bool IsShock, int i, double Mbh, double Nj, double Ucom, double velsw,
+bool Compton_check(bool IsShock, size_t i, double Mbh, double Nj, double Ucom, double velsw,
                    zone_pars &zone);
 
 void sum_counterjet(size_t size, const std::vector<double> &input_en,
@@ -124,7 +124,7 @@ void velprof_mag(jet_dynpars &dyn, gsl_spline *spline);
 void equipartition(int npsw, jet_dynpars &dyn, jet_enpars &en);
 void equipartition(double Nj, jet_dynpars &dyn, jet_enpars &en);
 
-void jetgrid(int i, grid_pars &grid, jet_dynpars &dyn, double r, double &delz, double &z);
+void jetgrid(size_t i, grid_pars &grid, jet_dynpars &dyn, double r, double &delz, double &z);
 void isojetpars(double z, jet_dynpars &dyn, jet_enpars &en, double &t, zone_pars &zone,
                 gsl_spline *spline, gsl_interp_accel *acc);
 void adjetpars(double z, jet_dynpars &dyn, jet_enpars &en, double &t, zone_pars &zone,
@@ -139,6 +139,6 @@ void zone_agn_phfields(double z, zone_pars &zone, double &ublr_zone, double &udt
 
 void clean_file(std::string path, int check);
 void jetinterp(std::vector<double> &ear, std::vector<double> &energ, std::vector<double> &phot,
-               std::vector<double> &photar, int ne, int newne);
+               std::vector<double> &photar, size_t ne, size_t newne);
 
 void ebl_atten_gil(int size, std::vector<double> &en, std::vector<double> &lum, double redsh);

--- a/examples/model/bhwrap.cpp
+++ b/examples/model/bhwrap.cpp
@@ -34,7 +34,7 @@ int main([[maybe_unused]] int argc, char *argv[]) {
     size_t ne = 201;
     double emin = -10;
     double emax = 10;
-    double einc = (emax - emin) / ne;
+    double einc = (emax - emin) / static_cast<double>(ne);
 
     std::vector<double> ebins(ne, 0.0);
     std::vector<double> param(npar, 0.0);
@@ -42,7 +42,7 @@ int main([[maybe_unused]] int argc, char *argv[]) {
     std::vector<double> dumarr(ne - 1, 0.0);
 
     for (size_t i = 0; i < ne; i++) {
-        ebins[i] = pow(10, (emin + i * einc));
+        ebins[i] = pow(10, (emin + static_cast<double>(i) * einc));
     }
 
     read_params(input_path, param);
@@ -65,7 +65,7 @@ void read_params(const std::string &path, std::vector<double> &pars) {
     std::ifstream inFile;
     inFile.open(path);
     std::string line;
-    int line_nb = 0;
+    size_t line_nb = 0;
     if (!inFile) {
         std::cerr << "Can't open input file: " << path << "\n";
         exit(1);

--- a/examples/model/jetpars.cpp
+++ b/examples/model/jetpars.cpp
@@ -71,9 +71,9 @@ void velprof_mag(jet_dynpars &dyn, gsl_spline *spline) {
     std::vector<double> gby_vel_mag(size, 0.0);
     double step;
 
-    step = (std::log10(dyn.max) + 1. - std::log10(dyn.min)) / (size - 3.);
+    step = (std::log10(dyn.max) + 1. - std::log10(dyn.min)) / static_cast<double>(size - 3);
     for (size_t i = 0; i < size; i++) {
-        gbx_vel_mag[i] = std::pow(10., std::log10(dyn.min) + i * step);
+        gbx_vel_mag[i] = std::pow(10., std::log10(dyn.min) + static_cast<double>(i) * step);
         if (gbx_vel_mag[i] < dyn.h0) {
             gby_vel_mag[i] = dyn.gam0;
         } else if (gbx_vel_mag[i] < dyn.acc) {
@@ -154,7 +154,7 @@ void equipartition(double Nj, jet_dynpars &dyn, jet_enpars &en) {
 }
 
 // Function to set up distance grid for calculations along the jet axies
-void jetgrid(int i, grid_pars &grid, jet_dynpars &dyn, double r, double &delz, double &z) {
+void jetgrid(size_t i, grid_pars &grid, jet_dynpars &dyn, double r, double &delz, double &z) {
     double zinc, z_next;
     // note: the distance grid changes in steps of 2r up to a distance zcut, and
     // then becomes logarithmic this prevents resolution errors for the IC
@@ -175,9 +175,11 @@ void jetgrid(int i, grid_pars &grid, jet_dynpars &dyn, double r, double &delz, d
         if (i == grid.cut) {
             grid.zcut = z + delz;
         }
-        zinc = (std::log10(dyn.max) - std::log10(grid.zcut)) / (grid.nz - grid.cut);
-        z = std::pow(10., std::log10(grid.zcut) + zinc * (i - grid.cut));
-        z_next = std::pow(10., std::log10(grid.zcut) + zinc * (i + 1 - grid.cut));
+        zinc =
+            (std::log10(dyn.max) - std::log10(grid.zcut)) / static_cast<double>(grid.nz - grid.cut);
+        z = std::pow(10., std::log10(grid.zcut) + zinc * static_cast<double>(i - grid.cut));
+        z_next =
+            std::pow(10., std::log10(grid.zcut) + zinc * static_cast<double>(i + 1 - grid.cut));
         delz = z_next - z;
     }
 }

--- a/examples/particles.cpp
+++ b/examples/particles.cpp
@@ -13,7 +13,7 @@ namespace karcst = kariba::constants;
 
 int main() {
 
-    int nel = 200;    // array size for particle distributions
+    size_t nel = 200;    // array size for particle distributions
 
     // Set the radius of the emitting regions in cm, the electron temperature,
     // the maximum Lorenz factor, magnetic field in the emitting region,

--- a/examples/singlezone.cpp
+++ b/examples/singlezone.cpp
@@ -14,8 +14,8 @@ namespace karcst = kariba::constants;
 
 int main() {
 
-    int nel = 100;      // array size for particle distributions
-    int nfreq = 200;    // array size for frequency arrays
+    size_t nel = 100;      // array size for particle distributions
+    size_t nfreq = 200;    // array size for frequency arrays
 
     double B, R,
         n;                        // plasma quantities of emitting region: bfield, radius, number

--- a/examples/utils.cpp
+++ b/examples/utils.cpp
@@ -10,7 +10,7 @@ void read_params(const std::string &path, std::vector<double> &pars) {
     std::ifstream inFile;
     inFile.open(path);
     std::string line;
-    int line_nb = 0;
+    size_t line_nb = 0;
     if (!inFile) {
         std::cerr << "Can't open input file\n";
         exit(1);
@@ -33,25 +33,25 @@ void read_params(const std::string &path, std::vector<double> &pars) {
 // file on the provided path. Note: the factor 1+z in
 // the specific luminosity calculation is to ensure that the output spectrum
 // only moves to lower frequency, not up/down.
-void plot_write(int size, const std::vector<double> &en, const std::vector<double> &lum,
+void plot_write(size_t size, const std::vector<double> &en, const std::vector<double> &lum,
                 const std::string &path, double redsh) {
     std::ofstream file;
     file.open(path, std::ios::app);
 
-    for (int k = 0; k < size; k++) {
+    for (size_t k = 0; k < size; k++) {
         file << en[k] / (karcst::herg * (1. + redsh)) << " " << lum[k] << "\n";
     }
 
     file.close();
 }
 
-void plot_write(int size, const std::vector<double> &p, const std::vector<double> &g,
+void plot_write(size_t size, const std::vector<double> &p, const std::vector<double> &g,
                 const std::vector<double> &pdens, const std::vector<double> &gdens,
                 const std::string &path) {
 
     std::ofstream file;
     file.open(path, std::ios::app);
-    for (int k = 0; k < size; k++) {
+    for (size_t k = 0; k < size; k++) {
         file << p[k] << " " << g[k] << " " << pdens[k] << " " << gdens[k] << "\n";
     }
 
@@ -98,10 +98,10 @@ void sum_ext(size_t size_in, size_t size_out, const std::vector<double> &input_e
 // erg/s/Hz for the luminosity array to be integrated, Hz for the integration
 // bounds; size is the dimension of the input arrays Note: this uses a VERY
 // rough method and wide bins, so thread carefully
-double integrate_lum(int size, double numin, double numax, const std::vector<double> &input_en,
+double integrate_lum(size_t size, double numin, double numax, const std::vector<double> &input_en,
                      const std::vector<double> &input_lum) {
     double temp = 0.;
-    for (int i = 0; i < size - 1; i++) {
+    for (size_t i = 0; i < size - 1; i++) {
         if (input_en[i] / karcst::herg > numin && input_en[i + 1] / karcst::herg < numax) {
             temp = temp + (1. / 2.) *
                               (input_en[i + 1] / karcst::herg - input_en[i] / karcst::herg) *
@@ -114,11 +114,11 @@ double integrate_lum(int size, double numin, double numax, const std::vector<dou
 // Overly simplified estimate of the photon index between numin and numax of a
 // given array; input is the same as integrate_lum. Note that this assumes
 // input_lum is a power-law in shape
-double photon_index(int size, double numin, double numax, const std::vector<double> &input_en,
+double photon_index(size_t size, double numin, double numax, const std::vector<double> &input_en,
                     const std::vector<double> &input_lum) {
-    int counter_1 = 0, counter_2 = 0;
+    size_t counter_1 = 0, counter_2 = 0;
     double delta_y, delta_x, gamma;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
         if (input_en[i] / karcst::herg < numin) {
             counter_1 = i;
         }

--- a/src/BBody.cpp
+++ b/src/BBody.cpp
@@ -16,10 +16,10 @@ void BBody::set_temp_kev(double T) {
     emin = 0.02 * constants::kboltz * Tbb;
     emax = 30. * constants::kboltz * Tbb;
 
-    einc = (log10(emax) - log10(emin)) / (en_phot.size() - 1);
+    einc = (log10(emax) - log10(emin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot[i] = pow(10., log10(emin) + i * einc);
+        en_phot[i] = pow(10., log10(emin) + static_cast<double>(i) * einc);
         en_phot_obs[i] = en_phot[i];
     }
 }
@@ -32,10 +32,10 @@ void BBody::set_temp_k(double T) {
     emin = 0.02 * constants::kboltz * Tbb;
     emax = 30. * constants::kboltz * Tbb;
 
-    einc = (log10(emax) - log10(emin)) / (en_phot.size() - 1);
+    einc = (log10(emax) - log10(emin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot[i] = pow(10., log10(emin) + i * einc);
+        en_phot[i] = pow(10., log10(emin) + static_cast<double>(i) * einc);
         en_phot_obs[i] = en_phot[i];
     }
 }
@@ -48,10 +48,10 @@ void BBody::set_temp_hz(double nu) {
     emin = 0.02 * constants::kboltz * Tbb;
     emax = 30. * constants::kboltz * Tbb;
 
-    einc = (log10(emax) - log10(emin)) / (en_phot.size() - 1);
+    einc = (log10(emax) - log10(emin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot[i] = pow(10., log10(emin) + i * einc);
+        en_phot[i] = pow(10., log10(emin) + static_cast<double>(i) * einc);
         en_phot_obs[i] = en_phot[i];
     }
 }

--- a/src/Bknpower.cpp
+++ b/src/Bknpower.cpp
@@ -23,10 +23,10 @@ void Bknpower::set_p(double min, double brk, double ucom, double bfield, double 
     pbrk = brk;
     pmax = max_p(ucom, bfield, betaeff, r, fsc);
 
-    double pinc = (log10(pmax) - log10(pmin)) / (p.size() - 1);
+    double pinc = (log10(pmax) - log10(pmin)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin) + i * pinc);
+        p[i] = pow(10., log10(pmin) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }
@@ -36,10 +36,10 @@ void Bknpower::set_p(double min, double brk, double gmax) {
     pbrk = brk;
     pmax = pow(pow(gmax, 2.) - 1., 1. / 2.) * mass_gr * constants::cee;
 
-    double pinc = (log10(pmax) - log10(pmin)) / (p.size() - 1);
+    double pinc = (log10(pmax) - log10(pmin)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin) + i * pinc);
+        p[i] = pow(10., log10(pmin) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }

--- a/src/Compton.cpp
+++ b/src/Compton.cpp
@@ -466,10 +466,10 @@ void Compton::set_tau(double _tau) { tau = _tau; }
 
 //! Method to set up the frequency array over desired range
 void Compton::set_frequency(double numin, double numax) {
-    double nuinc = (log10(numax) - log10(numin)) / (en_phot.size() - 1);
+    double nuinc = (log10(numax) - log10(numin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot[i] = pow(10., log10(numin) + i * nuinc) * constants::herg;
+        en_phot[i] = pow(10., log10(numin) + static_cast<double>(i) * nuinc) * constants::herg;
     }
 }
 

--- a/src/Cyclosyn.cpp
+++ b/src/Cyclosyn.cpp
@@ -234,7 +234,7 @@ double Cyclosyn::nu_syn(double gamma) {
 
 double Cyclosyn::nu_syn() {
     double temp_lum = 0.;
-    int temp = 0;
+    size_t temp = 0;
     for (size_t i = 0; i < num_phot.size(); i++) {
         if (num_phot[i] > temp_lum) {
             temp_lum = num_phot[i];
@@ -246,10 +246,10 @@ double Cyclosyn::nu_syn() {
 
 //! Method to set up the frequency array over desired range
 void Cyclosyn::set_frequency(double numin, double numax) {
-    double nuinc = (log10(numax) - log10(numin)) / (en_phot.size() - 1);
+    double nuinc = (log10(numax) - log10(numin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot[i] = pow(10., log10(numin) + i * nuinc) * constants::herg;
+        en_phot[i] = pow(10., log10(numin) + static_cast<double>(i) * nuinc) * constants::herg;
     }
 }
 

--- a/src/GammaRays.cpp
+++ b/src/GammaRays.cpp
@@ -29,9 +29,9 @@ Grays::Grays(size_t size, double numin, double numax) : Radiation(size) {
     num_phot_obs.resize(num_phot_obs.size() * 2, 0.0);
 
     size_t lsize = en_phot.size();
-    double nuinc = (log10(numax) - log10(numin)) / (lsize - 1);
+    double nuinc = (log10(numax) - log10(numin)) / static_cast<double>(lsize - 1);
     for (size_t i = 0; i < lsize; i++) {
-        en_phot[i] = pow(10., log10(numin) + i * nuinc) * constants::herg;
+        en_phot[i] = pow(10., log10(numin) + static_cast<double>(i) * nuinc) * constants::herg;
         en_phot_obs[i] = en_phot[i];
         en_phot_obs[i + lsize] = en_phot[i];
     }
@@ -298,9 +298,9 @@ void sum_photons(size_t nphot, const std::vector<double> &en_perseg,
 //************************************************************************************************************
 void Grays::set_grays_pg(double gp_min, double gp_max, gsl_interp_accel *acc_Jp,
                          gsl_spline *spline_Jp, std::vector<double> &en_perseg,
-                         std::vector<double> &lum_perseg, int nphot) {
+                         std::vector<double> &lum_perseg, size_t nphot) {
 
-    int N = 10;
+    size_t N = 10;
     double mpion =
         137.5e6 / constants::erg / (constants::cee * constants::cee);    // mass of pion in g
     double eta, deta;           // eta parameter: η = 4εE_p/(m_p^2*c^4) and its step
@@ -317,7 +317,7 @@ void Grays::set_grays_pg(double gp_min, double gp_max, gsl_interp_accel *acc_Jp,
     double dopfac_cj;
     dopfac_cj = dopfac * (1. - beta * cos(angle)) / (1. + beta * cos(angle));
 
-    for (int k = 0; k < nphot; k++) {
+    for (size_t k = 0; k < nphot; k++) {
         freq[k] = en_perseg[k] / constants::herg;    // Hz from erg
         Uphot[k] =
             lum_perseg[k] * (r / constants::cee /
@@ -329,7 +329,7 @@ void Grays::set_grays_pg(double gp_min, double gp_max, gsl_interp_accel *acc_Jp,
     gsl_spline *spline_ng = gsl_spline_alloc(gsl_interp_akima, nphot);
     gsl_spline_init(spline_ng, freq, Uphot, nphot);
 
-    deta = log10(eta_max / eta_min) / (N - 1);
+    deta = log10(eta_max / eta_min) / static_cast<double>(N - 1);
     size_t size = en_phot.size();
 #pragma omp parallel for private(eta, Hg, dNdEg)    // possibly lost: 9,424 bytes in 31 blocks
     for (size_t i = 0; i < size; i++) {             // for every produced γ ray energy
@@ -339,7 +339,7 @@ void Grays::set_grays_pg(double gp_min, double gp_max, gsl_interp_accel *acc_Jp,
             gsl_integration_workspace *w1 = gsl_integration_workspace_alloc(100);
             double result1, error1;
             gsl_function F1;
-            for (int j = 0; j < N; j++) {
+            for (size_t j = 0; j < N; j++) {
                 eta = eta_zero * (pow(10., log10(eta_min) + j * deta));
                 auto F1params = HetagParams{eta,    eta_zero,  Eg,     gp_min,
                                             gp_max, spline_Jp, acc_Jp,    // product,

--- a/src/Kappa.cpp
+++ b/src/Kappa.cpp
@@ -38,10 +38,10 @@ void Kappa::set_kappa(double k) { kappa = k; }
 void Kappa::set_p(double ucom, double bfield, double betaeff, double r, double fsc) {
     pmax = std::max(max_p(ucom, bfield, betaeff, r, fsc), pmax);
 
-    double pinc = (log10(pmax) - log10(pmin)) / (p.size() - 1);
+    double pinc = (log10(pmax) - log10(pmin)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin) + i * pinc);
+        p[i] = pow(10., log10(pmin) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }
@@ -50,10 +50,10 @@ void Kappa::set_p(double ucom, double bfield, double betaeff, double r, double f
 void Kappa::set_p(double gmax) {
     pmax = pow(pow(gmax, 2.) - 1., 1. / 2.) * mass_gr * constants::cee;
 
-    double pinc = (log10(pmax) - log10(pmin)) / (p.size() - 1);
+    double pinc = (log10(pmax) - log10(pmin)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin) + i * pinc);
+        p[i] = pow(10., log10(pmin) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }

--- a/src/Mixed.cpp
+++ b/src/Mixed.cpp
@@ -24,10 +24,10 @@ void Mixed::set_p(double ucom, double bfield, double betaeff, double r, double f
     pmin_pl = av_th_p();
     pmax_pl = std::max(max_p(ucom, bfield, betaeff, r, fsc), pmax_th);
 
-    double pinc = (log10(pmax_pl) - log10(pmin_th)) / (p.size() - 1);
+    double pinc = (log10(pmax_pl) - log10(pmin_th)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin_th) + i * pinc);
+        p[i] = pow(10., log10(pmin_th) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }
@@ -37,10 +37,10 @@ void Mixed::set_p(double gmax) {
     pmin_pl = av_th_p();
     pmax_pl = pow(pow(gmax, 2.) - 1., 1. / 2.) * mass_gr * constants::cee;
 
-    double pinc = (log10(pmax_pl) - log10(pmin_th)) / (size - 1);
+    double pinc = (log10(pmax_pl) - log10(pmin_th)) / static_cast<double>(size - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin_th) + i * pinc);
+        p[i] = pow(10., log10(pmin_th) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }

--- a/src/Neutrinos_pg.cpp
+++ b/src/Neutrinos_pg.cpp
@@ -88,9 +88,9 @@ Neutrinos_pg::Neutrinos_pg(size_t lsize, double Emin, double Emax) : Radiation(l
     en_phot_obs.resize(2 * en_phot_obs.size(), 0.0);
     num_phot_obs.resize(2 * num_phot_obs.size(), 0.0);
 
-    double Einc = log10(Emax / Emin) / (lsize - 1);
+    double einc = log10(Emax / Emin) / static_cast<double>(lsize - 1);
     for (size_t i = 0; i < lsize; i++) {
-        en_phot[i] = pow(10., log10(Emin) + i * Einc);
+        en_phot[i] = pow(10., log10(Emin) + static_cast<double>(i) * einc);
         en_phot_obs[i] = en_phot[i];
         en_phot_obs[i + lsize] = en_phot[i];
     }
@@ -161,7 +161,7 @@ void Neutrinos_pg::set_neutrinos(double gp_min, double gp_max, gsl_interp_accel 
             double result1, error1;
             gsl_function F1;
             for (size_t j = 0; j < N; j++) {    // eq 69 from KA08
-                eta = eta_zero * (pow(10., log10(eta_min) + j * deta));
+                eta = eta_zero * (pow(10., log10(eta_min) + static_cast<double>(j) * deta));
                 auto F1params = HetaParams{eta,    eta_zero, Ev,     gp_min,    gp_max, spline_Jp,
                                            acc_Jp, flavor,   acc_ng, spline_ng, nu_min, nu_max};
                 F1.function = &Heta;

--- a/src/Neutrinos_pp.cpp
+++ b/src/Neutrinos_pp.cpp
@@ -13,9 +13,9 @@ Neutrinos_pp::Neutrinos_pp(size_t size, double Emin, double Emax) : Radiation(si
     en_phot_obs.resize(2 * en_phot_obs.size(), 0.0);
     num_phot_obs.resize(2 * num_phot_obs.size(), 0.0);
 
-    double Einc = log10(Emax / Emin) / (size - 1);
+    double einc = log10(Emax / Emin) / static_cast<double>(size - 1);
     for (size_t i = 0; i < size; i++) {
-        en_phot[i] = pow(10., log10(Emin) + i * Einc);
+        en_phot[i] = pow(10., log10(Emin) + static_cast<double>(i) * einc);
         en_phot_obs[i] = en_phot[i];
         en_phot_obs[i + size] = en_phot[i];
     }
@@ -139,13 +139,13 @@ double prob_fve() {    // it is the same as of electrons
     size_t N = 20;                  // The steps of integration.
     double r = .573;                // r = 1-λ = m_μ^2/m_p^2 = 0.573.
     double xmin = 0., xmax = 1.;    // x = E_{particle}/E_p.
-    double x, dx = (xmax - xmin) / (N - 1);
+    double x, dx = (xmax - xmin) / static_cast<double>(N - 1);
     double gn, hn1, hn2, fve;    // (equations 40-43 from Kelner et al. 2006)
     double sum = 0.;
     double Bprob;
 
     for (size_t i = 0; i < N; i++) {
-        x = xmin + i * dx;
+        x = xmin + static_cast<double>(i) * dx;
         gn = 2. / (3. * (1. - r) * (1. - r)) *
              ((1. - x) * (6. * (1. - x) * (1. - x) + r * (5. + 5. * x - 4. * x * x)) +
               6. * r * log(x));

--- a/src/Powerlaw.cpp
+++ b/src/Powerlaw.cpp
@@ -25,10 +25,10 @@ void Powerlaw::set_p(double min, double ucom, double bfield, double betaeff, dou
     pmin = min;
     pmax = max_p(ucom, bfield, betaeff, r, fsc);
 
-    double pinc = (log10(pmax) - log10(pmin)) / (p.size() - 1);
+    double pinc = (log10(pmax) - log10(pmin)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin) + i * pinc);
+        p[i] = pow(10., log10(pmin) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }
@@ -37,10 +37,10 @@ void Powerlaw::set_p(double min, double gmax) {
     pmin = min;
     pmax = pow(pow(gmax, 2.) - 1., 1. / 2.) * mass_gr * constants::cee;
 
-    double pinc = (log10(pmax) - log10(pmin)) / (p.size() - 1);
+    double pinc = (log10(pmax) - log10(pmin)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin) + i * pinc);
+        p[i] = pow(10., log10(pmin) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }
@@ -162,13 +162,14 @@ void Powerlaw::set_energy(double gpmin, double fsc, double f_beta, double bfield
     } else {
         isEfficient = true;
         gpmax = fsc;
-        logdgp = log10(2. * gpmax / gpmin) /
-                 (gamma.size() - 1);    // so as to extend a bit further from γ_p,max
+        logdgp =
+            log10(2. * gpmax / gpmin) /
+            static_cast<double>(gamma.size() - 1);    // so as to extend a bit further from γ_p,max
         check_secondary_charged_syn(bfield, gpmax);
     }
 
     for (size_t i = 0; i < gamma.size(); i++) {
-        gamma[i] = pow(10., (log10(gpmin) + i * logdgp));
+        gamma[i] = pow(10., (log10(gpmin) + static_cast<double>(i) * logdgp));
         p[i] = sqrt(gamma[i] * gamma[i] - 1.) * mass_gr * constants::cee;
     }
     pmin = p[0];
@@ -215,18 +216,20 @@ void Powerlaw::ProtonTimescales(double &logdgp, double fsc, double f_beta, doubl
     gpmax = Epmax / (constants::pmgm * constants::cee * constants::cee) + 1.;
     if (Epmax > constants::pmgm * constants::cee * constants::cee) {
         isEfficient = true;
-        logdgp = log10(2. * gpmax / gpmin) /
-                 (gamma.size() - 1);    // so as to extend a bit further from γ_p,max
+        logdgp =
+            log10(2. * gpmax / gpmin) /
+            static_cast<double>(gamma.size() - 1);    // so as to extend a bit further from γ_p,max
     } else {
         isEfficient = false;
-        logdgp = log10(10.) / (gamma.size() - 1);    // make an array between 1 and 10 GeV
+        logdgp = log10(10.) /
+                 static_cast<double>(gamma.size() - 1);    // make an array between 1 and 10 GeV
     }
     if (infosw >= 2) {
         std::string filepath =
             outputConfiguration + "/Output/Particles/timescales_" + source + ".dat";
         timescalesFile.open(filepath, std::ios::app);
         for (size_t i = 0; i < gamma.size(); i++) {
-            gp = pow(10., (log10(gpmin) + i * logdgp));
+            gp = pow(10., (log10(gpmin) + static_cast<double>(i) * logdgp));
             betap = sqrt(gp * gp - 1.) / gp;
             tescape = r / (constants::cee * betap * f_beta);
 
@@ -454,7 +457,8 @@ void Powerlaw::set_pp_elecs(gsl_interp_accel *acc_Jp, gsl_spline *spline_Jp, dou
 
     // Loop for every electron energy
     for (size_t j = 0; j < gamma.size(); j++) {
-        gamma[j] = pow(10., log10(gmin) + j * log10(gmax / gmin) / (gamma.size() - 1));
+        gamma[j] = pow(10., log10(gmin) + static_cast<double>(j) * log10(gmax / gmin) /
+                                              static_cast<double>(gamma.size() - 1));
         Ee = gamma[j] * constants::emerg * constants::erg * 1.e-12;    // in TeV
         if (Ee < transition) {
             Epimin = Ee + constants::mpionTeV * constants::mpionTeV / (4. * Ee);
@@ -462,7 +466,8 @@ void Powerlaw::set_pp_elecs(gsl_interp_accel *acc_Jp, gsl_spline *spline_Jp, dou
             dw = (log10(Epimax / Epimin)) / (N - 1);
             sum = 0.;
             for (size_t i = 0; i < N; i++) {
-                lEpi = log10(Epimin) + i * dw;    // The exponent of the pion energy.
+                lEpi = log10(Epimin) +
+                       static_cast<double>(i) * dw;    // The exponent of the pion energy.
                 Ep = constants::mprotTeV +
                      pow(10., lEpi) / constants::Kpi;    // The mass of the proton in TeV.
                 sinel = sigma_pp(Ep);
@@ -481,7 +486,7 @@ void Powerlaw::set_pp_elecs(gsl_interp_accel *acc_Jp, gsl_spline *spline_Jp, dou
         } else if ((Ee >= transition) && (Ee <= Epcode_max)) {
             sum = 0.;
             for (size_t i = 0; i < N; i++) {    // The loop over all pion energies.
-                y = ymin + i * dy;
+                y = ymin + static_cast<double>(i) * dy;
                 Ep = pow(10., (log10(Ee) - y));    // Proton enrergy in TeV.
                 if (Ep <= Epcode_max) {
                     sinel = sigma_pp(Ep);
@@ -594,7 +599,8 @@ void Powerlaw::Qggeefunction(double r, double vol, double bfield, size_t phot_nu
     gsl_spline_init(spline_lNg, logx.data(), logNgamma.data(), phot_number);
 
     for (size_t i = 0; i < gamma.size(); i++) {
-        gamma[i] = pow(10., log10(gmin) + i * log10(gmax / gmin) / (gamma.size() - 1));
+        gamma[i] = pow(10., log10(gmin) + static_cast<double>(i) * log10(gmax / gmin) /
+                                              static_cast<double>(gamma.size() - 1));
         Eg = log10(2. * gamma[i]);    // 2γ from MK95
 
         if (Eg >= logx[1] && Eg <= logx[phot_number - 1]) {

--- a/src/ShSDisk.cpp
+++ b/src/ShSDisk.cpp
@@ -96,10 +96,10 @@ void ShSDisk::set_luminosity(double L) {
     Hratio = std::max(0.1, Ldisk);
     emin = 0.0001 * constants::kboltz * Tin;
     emax = 30. * constants::kboltz * Tin;
-    einc = (log10(emax) - log10(emin)) / (en_phot.size() - 1);
+    einc = (log10(emax) - log10(emin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot_obs[i] = pow(10., log10(emin) + i * einc);
+        en_phot_obs[i] = pow(10., log10(emin) + static_cast<double>(i) * einc);
         en_phot[i] = en_phot_obs[i];
         num_phot[i] = 0.;
         num_phot_obs[i] = 0.;
@@ -115,10 +115,10 @@ void ShSDisk::set_tin_kev(double T) {
     Hratio = std::max(0.1, Ldisk);
     emin = 0.0001 * constants::kboltz * Tin;
     emax = 30. * constants::kboltz * Tin;
-    einc = (log10(emax) - log10(emin)) / (en_phot.size() - 1);
+    einc = (log10(emax) - log10(emin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot_obs[i] = pow(10., log10(emin) + i * einc);
+        en_phot_obs[i] = pow(10., log10(emin) + static_cast<double>(i) * einc);
         en_phot[i] = en_phot_obs[i];
         num_phot[i] = 0.;
         num_phot_obs[i] = 0.;
@@ -133,10 +133,10 @@ void ShSDisk::set_tin_k(double T) {
     Hratio = std::max(0.1, Ldisk);
     emin = 0.0001 * constants::kboltz * Tin;
     emax = 30. * constants::kboltz * Tin;
-    einc = (log10(emax) - log10(emin)) / (en_phot.size() - 1);
+    einc = (log10(emax) - log10(emin)) / static_cast<double>(en_phot.size() - 1);
 
     for (size_t i = 0; i < en_phot.size(); i++) {
-        en_phot_obs[i] = pow(10., log10(emin) + i * einc);
+        en_phot_obs[i] = pow(10., log10(emin) + static_cast<double>(i) * einc);
         en_phot[i] = en_phot_obs[i];
         num_phot[i] = 0.;
         num_phot_obs[i] = 0.;

--- a/src/Thermal.cpp
+++ b/src/Thermal.cpp
@@ -27,10 +27,10 @@ void Thermal::set_p() {
 
     pmin = pow(pow(gmin, 2.) - 1., 1. / 2.) * mass_gr * constants::cee;
     pmax = pow(pow(gmax, 2.) - 1., 1. / 2.) * mass_gr * constants::cee;
-    pinc = (log10(pmax) - log10(pmin)) / (p.size() - 1);
+    pinc = (log10(pmax) - log10(pmin)) / static_cast<double>(p.size() - 1);
 
     for (size_t i = 0; i < p.size(); i++) {
-        p[i] = pow(10., log10(pmin) + i * pinc);
+        p[i] = pow(10., log10(pmin) + static_cast<double>(i) * pinc);
         gamma[i] = pow(pow(p[i] / (mass_gr * constants::cee), 2.) + 1., 1. / 2.);
     }
 }

--- a/src/kariba/GammaRays.hpp
+++ b/src/kariba/GammaRays.hpp
@@ -38,7 +38,7 @@ class Grays : public Radiation {
                       gsl_spline *spline_Jp);
 
     void set_grays_pg(double gp_min, double gp_max, gsl_interp_accel *acc_Jp, gsl_spline *spline_Jp,
-                      std::vector<double> &nu_per_seg, std::vector<double> &ng_per_seg, int ne);
+                      std::vector<double> &nu_per_seg, std::vector<double> &ng_per_seg, size_t ne);
 };
 
 //! Adds up in the lum_perseg the target photon luminosity (in erg/sec/Hz)

--- a/src/kariba/Radiation.hpp
+++ b/src/kariba/Radiation.hpp
@@ -93,7 +93,7 @@ class Radiation {
 
     const std::vector<double> &get_nphot_obs() const { return num_phot_obs; }
 
-    int get_size() const { return size; }
+    size_t get_size() const { return size; }
 
     double get_volume() const { return vol; }
 

--- a/tests/test_bknpower.cpp
+++ b/tests/test_bknpower.cpp
@@ -10,7 +10,7 @@ namespace karcst = kariba::constants;
 TEST_CASE("Bknpower tests") {
     SUBCASE("Simple Bknpower usage") {
 
-        int nel = 50;
+        size_t nel = 50;
         double gmax = 1e3;
         double s = 2.0;
         double pbreak = 8.65822e-17;
@@ -30,7 +30,6 @@ TEST_CASE("Bknpower tests") {
         CHECK(bknpower.count_particles() > 0.0);
 
         // Test cooling
-        CHECK_NOTHROW(
-            bknpower.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
+        CHECK_NOTHROW(bknpower.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
     }
 }

--- a/tests/test_compton.cpp
+++ b/tests/test_compton.cpp
@@ -16,8 +16,8 @@ TEST_CASE("Integration tests - Complete workflows") {
     SUBCASE("Single zone jet model workflow") {
         // This test replicates the singlezone example workflow
 
-        int nel = 50;    // Smaller arrays for faster testing
-        int nfreq = 50;
+        size_t nel = 50;    // Smaller arrays for faster testing
+        size_t nfreq = 50;
 
         // Model parameters (simplified from example)
         double Mbh = 6.5e9;
@@ -46,8 +46,8 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_interp_accel *acc_deriv = gsl_interp_accel_alloc();
         gsl_spline *spline_deriv = gsl_spline_alloc(gsl_interp_steffen, nel);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma().data(),
-                        electrons.get_gdens().data(), nel);
+        gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
+                        nel);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
                         electrons.get_gdens_diff().data(), nel);
 
@@ -61,8 +61,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         double gmin_actual = electrons.get_gamma()[0];
         double gmax_actual = electrons.get_gamma()[nel - 1];
 
-        CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin_actual, gmax_actual,
-                                             spline_eldis, acc_eldis,
+        CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin_actual, gmax_actual, spline_eldis, acc_eldis,
                                              spline_deriv, acc_deriv));
 
         // Verify synchrotron spectrum
@@ -70,7 +69,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         const std::vector<double> &syn_flux = syncro.get_nphot();
 
         bool has_syn_emission = false;
-        for (int i = 0; i < nfreq; i++) {
+        for (size_t i = 0; i < nfreq; i++) {
             CHECK(syn_energy[i] > 0.0);
             if (syn_flux[i] > 0.0) {
                 has_syn_emission = true;
@@ -88,17 +87,15 @@ TEST_CASE("Integration tests - Complete workflows") {
         // Use synchrotron photons as seed
         ssc.cyclosyn_seed(syncro.get_energy(), syncro.get_nphot());
 
-        CHECK_NOTHROW(ssc.compton_spectrum(gmin_actual, gmax_actual,
-                                           spline_eldis, acc_eldis));
+        CHECK_NOTHROW(ssc.compton_spectrum(gmin_actual, gmax_actual, spline_eldis, acc_eldis));
 
         // Verify SSC spectrum
         const std::vector<double> &ssc_energy = ssc.get_energy();
         const std::vector<double> &ssc_flux = ssc.get_nphot();
 
         bool has_ssc_emission = false;
-        for (int i = 0; i < nfreq; i++) {
-            CHECK(ssc_energy[i] >=
-                  syn_energy[nfreq - 1]);    // SSC should be higher energy
+        for (size_t i = 0; i < nfreq; i++) {
+            CHECK(ssc_energy[i] >= syn_energy[nfreq - 1]);    // SSC should be higher energy
             if (ssc_flux[i] > 0.0) {
                 has_ssc_emission = true;
             }
@@ -124,8 +121,8 @@ TEST_CASE("Integration tests - Complete workflows") {
     SUBCASE("Corona Comptonization workflow") {
         // This test replicates the corona example workflow
 
-        int nel = 50;
-        int nfreq = 50;
+        size_t nel = 50;
+        size_t nfreq = 50;
 
         // Parameters
         double Mbh = 10.0;
@@ -170,8 +167,8 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_interp_accel *acc_eldis = gsl_interp_accel_alloc();
         gsl_spline *spline_eldis = gsl_spline_alloc(gsl_interp_steffen, nel);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma().data(),
-                        electrons.get_gdens().data(), nel);
+        gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
+                        nel);
 
         // Set up Comptonization
         kariba::Compton ic(nfreq, 50);    // 50 is disk spectrum size
@@ -182,8 +179,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         ic.set_niter(5);    // Reduced iterations for testing
 
         // Use disk as seed photon field
-        ic.shsdisk_seed(disk.get_energy(), disk.tin(), Rin, Rout, disk.hdisk(),
-                        0.0);
+        ic.shsdisk_seed(disk.get_energy(), disk.tin(), Rin, Rout, disk.hdisk(), 0.0);
 
         double gmin = electrons.get_gamma()[0];
         double gmax = electrons.get_gamma()[nel - 1];
@@ -195,7 +191,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         const std::vector<double> &ic_flux = ic.get_nphot();
 
         bool has_ic_emission = false;
-        for (int i = 0; i < nfreq; i++) {
+        for (size_t i = 0; i < nfreq; i++) {
             CHECK(ic_energy[i] > 0.0);
             if (ic_flux[i] > 0.0) {
                 has_ic_emission = true;
@@ -205,8 +201,7 @@ TEST_CASE("Integration tests - Complete workflows") {
 
         // Check that Compton spectrum extends to higher energies than disk
         const std::vector<double> &disk_energy = disk.get_energy();
-        CHECK(ic_energy[nfreq - 1] >
-              disk_energy[49]);    // IC should extend higher
+        CHECK(ic_energy[nfreq - 1] > disk_energy[49]);    // IC should extend higher
 
         // Cleanup
         gsl_spline_free(spline_eldis);

--- a/tests/test_cyclosyn.cpp
+++ b/tests/test_cyclosyn.cpp
@@ -46,10 +46,8 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_interp_accel *acc_deriv = gsl_interp_accel_alloc();
         gsl_spline *spline_deriv = gsl_spline_alloc(gsl_interp_steffen, nel);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma(),
-                        electrons.get_gdens(), nel);
-        gsl_spline_init(spline_deriv, electrons.get_gamma(),
-                        electrons.get_gdens_diff(), nel);
+        gsl_spline_init(spline_eldis, electrons.get_gamma(), electrons.get_gdens(), nel);
+        gsl_spline_init(spline_deriv, electrons.get_gamma(), electrons.get_gdens_diff(), nel);
 
         // Calculate synchrotron emission
         kariba::Cyclosyn syncro(nfreq);
@@ -61,8 +59,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         double gmin_actual = electrons.get_gamma()[0];
         double gmax_actual = electrons.get_gamma()[nel - 1];
 
-        CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin_actual, gmax_actual,
-                                             spline_eldis, acc_eldis,
+        CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin_actual, gmax_actual, spline_eldis, acc_eldis,
                                              spline_deriv, acc_deriv));
 
         // Verify synchrotron spectrum
@@ -88,8 +85,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         // Use synchrotron photons as seed
         ssc.cyclosyn_seed(syncro.get_energy(), syncro.get_nphot());
 
-        CHECK_NOTHROW(ssc.compton_spectrum(gmin_actual, gmax_actual,
-                                           spline_eldis, acc_eldis));
+        CHECK_NOTHROW(ssc.compton_spectrum(gmin_actual, gmax_actual, spline_eldis, acc_eldis));
 
         // Verify SSC spectrum
         double *ssc_energy = ssc.get_energy();
@@ -97,8 +93,7 @@ TEST_CASE("Integration tests - Complete workflows") {
 
         bool has_ssc_emission = false;
         for (int i = 0; i < nfreq; i++) {
-            CHECK(ssc_energy[i] >=
-                  syn_energy[nfreq - 1]);    // SSC should be higher energy
+            CHECK(ssc_energy[i] >= syn_energy[nfreq - 1]);    // SSC should be higher energy
             if (ssc_flux[i] > 0.0) {
                 has_ssc_emission = true;
             }

--- a/tests/test_distributions.cpp
+++ b/tests/test_distributions.cpp
@@ -18,8 +18,8 @@ TEST_CASE("Integration tests - Complete workflows") {
     SUBCASE("Single zone jet model workflow") {
         // This test replicates the singlezone example workflow
 
-        int nel = 50;    // Smaller arrays for faster testing
-        int nfreq = 50;
+        size_t nel = 50;    // Smaller arrays for faster testing
+        size_t nfreq = 50;
 
         // Model parameters (simplified from example)
         double Mbh = 6.5e9;
@@ -48,8 +48,8 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_interp_accel *acc_deriv = gsl_interp_accel_alloc();
         gsl_spline *spline_deriv = gsl_spline_alloc(gsl_interp_steffen, nel);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma().data(),
-                        electrons.get_gdens().data(), nel);
+        gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
+                        nel);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
                         electrons.get_gdens_diff().data(), nel);
 
@@ -63,8 +63,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         double gmin_actual = electrons.get_gamma()[0];
         double gmax_actual = electrons.get_gamma()[nel - 1];
 
-        CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin_actual, gmax_actual,
-                                             spline_eldis, acc_eldis,
+        CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin_actual, gmax_actual, spline_eldis, acc_eldis,
                                              spline_deriv, acc_deriv));
 
         // Verify synchrotron spectrum
@@ -72,7 +71,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         const std::vector<double> &syn_flux = syncro.get_nphot();
 
         bool has_syn_emission = false;
-        for (int i = 0; i < nfreq; i++) {
+        for (size_t i = 0; i < nfreq; i++) {
             CHECK(syn_energy[i] > 0.0);
             if (syn_flux[i] > 0.0) {
                 has_syn_emission = true;
@@ -90,18 +89,15 @@ TEST_CASE("Integration tests - Complete workflows") {
         // Use synchrotron photons as seed
         ssc.cyclosyn_seed(syncro.get_energy(), syncro.get_nphot());
 
-        CHECK_NOTHROW(ssc.compton_spectrum(gmin_actual, gmax_actual,
-                                           spline_eldis, acc_eldis));
+        CHECK_NOTHROW(ssc.compton_spectrum(gmin_actual, gmax_actual, spline_eldis, acc_eldis));
 
         // Verify SSC spectrum
         const std::vector<double> &ssc_energy = ssc.get_energy();
         const std::vector<double> &ssc_flux = ssc.get_nphot();
 
         bool has_ssc_emission = false;
-        for (int i = 0; i < nfreq; i++) {
-            CHECK(
-                ssc_energy[i] >=
-                syn_energy[nfreq - 1]);    // SSC should be higher/equal energy
+        for (size_t i = 0; i < nfreq; i++) {
+            CHECK(ssc_energy[i] >= syn_energy[nfreq - 1]);    // SSC should be higher/equal energy
             if (ssc_flux[i] > 0.0) {
                 has_ssc_emission = true;
             }
@@ -127,8 +123,8 @@ TEST_CASE("Integration tests - Complete workflows") {
     SUBCASE("Corona Comptonization workflow") {
         // This test replicates the corona example workflow
 
-        int nel = 50;
-        int nfreq = 50;
+        size_t nel = 50;
+        size_t nfreq = 50;
 
         // Parameters
         double Mbh = 10.0;
@@ -173,8 +169,8 @@ TEST_CASE("Integration tests - Complete workflows") {
         gsl_interp_accel *acc_eldis = gsl_interp_accel_alloc();
         gsl_spline *spline_eldis = gsl_spline_alloc(gsl_interp_steffen, nel);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma().data(),
-                        electrons.get_gdens().data(), nel);
+        gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
+                        nel);
 
         // Set up Comptonization
         kariba::Compton ic(nfreq, 50);    // 50 is disk spectrum size
@@ -185,8 +181,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         ic.set_niter(5);    // Reduced iterations for testing
 
         // Use disk as seed photon field
-        ic.shsdisk_seed(disk.get_energy(), disk.tin(), Rin, Rout, disk.hdisk(),
-                        0.0);
+        ic.shsdisk_seed(disk.get_energy(), disk.tin(), Rin, Rout, disk.hdisk(), 0.0);
 
         double gmin = electrons.get_gamma()[0];
         double gmax = electrons.get_gamma()[nel - 1];
@@ -198,7 +193,7 @@ TEST_CASE("Integration tests - Complete workflows") {
         const std::vector<double> &ic_flux = ic.get_nphot();
 
         bool has_ic_emission = false;
-        for (int i = 0; i < nfreq; i++) {
+        for (size_t i = 0; i < nfreq; i++) {
             CHECK(ic_energy[i] > 0.0);
             if (ic_flux[i] > 0.0) {
                 has_ic_emission = true;
@@ -208,8 +203,7 @@ TEST_CASE("Integration tests - Complete workflows") {
 
         // Check that Compton spectrum extends to higher energies than disk
         const std::vector<double> &disk_energy = disk.get_energy();
-        CHECK(ic_energy[nfreq - 1] >
-              disk_energy[49]);    // IC should extend higher
+        CHECK(ic_energy[nfreq - 1] > disk_energy[49]);    // IC should extend higher
 
         // Cleanup
         gsl_spline_free(spline_eldis);
@@ -219,7 +213,7 @@ TEST_CASE("Integration tests - Complete workflows") {
     SUBCASE("Particle distribution comparison workflow") {
         // This test replicates the particles example workflow
 
-        int nel = 50;
+        size_t nel = 50;
 
         // Common parameters
         double Te = 511.0;    // keV
@@ -299,13 +293,10 @@ TEST_CASE("Integration tests - Complete workflows") {
         double R = 1e10;
         double beta_exp = 0.1;
 
-        CHECK_NOTHROW(
-            mixed_low.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
-        CHECK_NOTHROW(
-            mixed_high.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
+        CHECK_NOTHROW(mixed_low.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
+        CHECK_NOTHROW(mixed_high.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
         CHECK_NOTHROW(kappa.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
-        CHECK_NOTHROW(
-            bknpower.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
+        CHECK_NOTHROW(bknpower.cooling_steadystate(0.0, 1.0, bfield, R, beta_exp));
     }
 }
 
@@ -353,10 +344,8 @@ TEST_CASE("Error handling and edge cases") {
 
         // Very massive black hole
         disk.set_mbh(1e10);
-        disk.set_rin(6.0 * karcst::gconst * 1e10 * karcst::msun /
-                     karcst::cee_cee);
-        disk.set_rout(1e5 * karcst::gconst * 1e10 * karcst::msun /
-                      karcst::cee_cee);
+        disk.set_rin(6.0 * karcst::gconst * 1e10 * karcst::msun / karcst::cee_cee);
+        disk.set_rout(1e5 * karcst::gconst * 1e10 * karcst::msun / karcst::cee_cee);
         disk.set_luminosity(0.1);
 
         CHECK_NOTHROW(disk.disk_spectrum());

--- a/tests/test_particles.cpp
+++ b/tests/test_particles.cpp
@@ -75,8 +75,8 @@ TEST_CASE("Particles subclass functionality") {
 
             // Check relativistic energy-momentum relation for first few points
             for (size_t i = 0; i < 5; i++) {
-                double expected_gamma = std::sqrt(
-                    1.0 + std::pow(p[i] / (karcst::emgm * karcst::cee), 2.0));
+                double expected_gamma =
+                    std::sqrt(1.0 + std::pow(p[i] / (karcst::emgm * karcst::cee), 2.0));
                 CHECK(std::abs(gamma[i] - expected_gamma) < 1e-10);
             }
         }
@@ -136,8 +136,7 @@ TEST_CASE("Particles subclass functionality") {
             double r = 1e10;
             double tshift = 0.1;
 
-            CHECK_NOTHROW(
-                powerlaw.cooling_steadystate(ucom, n0, bfield, r, tshift));
+            CHECK_NOTHROW(powerlaw.cooling_steadystate(ucom, n0, bfield, r, tshift));
         }
     }
 
@@ -238,8 +237,8 @@ TEST_CASE("Particle distribution consistency checks") {
 
         // Check relativistic energy-momentum relation: E^2 = (pc)^2 + (mc^2)^2
         for (size_t i = 0; i < 10; i++) {
-            double expected_gamma = std::sqrt(
-                1.0 + std::pow(p[i] / (karcst::emgm * karcst::cee), 2.0));
+            double expected_gamma =
+                std::sqrt(1.0 + std::pow(p[i] / (karcst::emgm * karcst::cee), 2.0));
             CHECK(std::abs(gamma[i] - expected_gamma) < 1e-10);
         }
     }

--- a/tests/test_powerlaw.cpp
+++ b/tests/test_powerlaw.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Integration tests - Complete workflows") {
     SUBCASE("Single zone jet model workflow") {
         // This test replicates the singlezone example workflow
 
-        int nel = 50;    // Smaller arrays for faster testing
+        size_t nel = 50;    // Smaller arrays for faster testing
 
         double B = 1.5e-3;
         double n = 9.5e-3;

--- a/tests/test_radiation.cpp
+++ b/tests/test_radiation.cpp
@@ -18,10 +18,8 @@ TEST_CASE("Radiation base class functionality") {
 
         SUBCASE("Basic disk parameters") {
             double mbh = 10.0;    // 10 solar masses
-            double rin =
-                10.0 * karcst::gconst * mbh * karcst::msun / karcst::cee_cee;
-            double rout =
-                1e4 * karcst::gconst * mbh * karcst::msun / karcst::cee_cee;
+            double rin = 10.0 * karcst::gconst * mbh * karcst::msun / karcst::cee_cee;
+            double rout = 1e4 * karcst::gconst * mbh * karcst::msun / karcst::cee_cee;
             double ldisk = 1e-4;    // Eddington units
 
             disk.set_mbh(mbh);
@@ -56,7 +54,7 @@ TEST_CASE("Radiation base class functionality") {
             const std::vector<double> &nphot = disk.get_nphot_obs();
 
             bool has_positive_flux = false;
-            for (int i = 0; i < disk.get_size(); i++) {
+            for (size_t i = 0; i < disk.get_size(); i++) {
                 CHECK(energy[i] > 0.0);
                 if (nphot[i] > 0.0) {
                     has_positive_flux = true;
@@ -67,10 +65,8 @@ TEST_CASE("Radiation base class functionality") {
 
         SUBCASE("Disk geometry and beaming") {
             disk.set_mbh(10.0);
-            disk.set_rin(10.0 * karcst::gconst * 10.0 * karcst::msun /
-                         karcst::cee_cee);
-            disk.set_rout(1e4 * karcst::gconst * 10.0 * karcst::msun /
-                          karcst::cee_cee);
+            disk.set_rin(10.0 * karcst::gconst * 10.0 * karcst::msun / karcst::cee_cee);
+            disk.set_rout(1e4 * karcst::gconst * 10.0 * karcst::msun / karcst::cee_cee);
             disk.set_luminosity(1e-4);
 
             // Test different inclination angles
@@ -105,7 +101,7 @@ TEST_CASE("Radiation base class functionality") {
             // Check that all energies are positive and increasing
             bool increasing = true;
             bool has_positive_flux = false;
-            for (int i = 0; i < bbody.get_size(); i++) {
+            for (size_t i = 0; i < bbody.get_size(); i++) {
                 CHECK(energy[i] > 0.0);
                 if (i > 0 && energy[i] <= energy[i - 1]) {
                     increasing = false;
@@ -143,8 +139,8 @@ TEST_CASE("Synchrotron radiation") {
         gsl_interp_accel *acc_deriv = gsl_interp_accel_alloc();
         gsl_spline *spline_deriv = gsl_spline_alloc(gsl_interp_steffen, 100);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma().data(),
-                        electrons.get_gdens().data(), 100);
+        gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
+                        100);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
                         electrons.get_gdens_diff().data(), 100);
 
@@ -160,8 +156,7 @@ TEST_CASE("Synchrotron radiation") {
             double gmin = electrons.get_gamma()[0];
             double gmax_actual = electrons.get_gamma()[99];
 
-            CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin, gmax_actual,
-                                                 spline_eldis, acc_eldis,
+            CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin, gmax_actual, spline_eldis, acc_eldis,
                                                  spline_deriv, acc_deriv));
 
             CHECK(!syncro.get_energy().empty());
@@ -170,7 +165,7 @@ TEST_CASE("Synchrotron radiation") {
             // Check for positive flux somewhere
             const std::vector<double> &nphot = syncro.get_nphot();
             bool has_flux = false;
-            for (int i = 0; i < syncro.get_size(); i++) {
+            for (size_t i = 0; i < syncro.get_size(); i++) {
                 if (nphot[i] > 0.0) {
                     has_flux = true;
                 }
@@ -193,8 +188,7 @@ TEST_CASE("Synchrotron radiation") {
             double gmin = electrons.get_gamma()[0];
             double gmax_actual = electrons.get_gamma()[99];
 
-            CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin, gmax_actual,
-                                                 spline_eldis, acc_eldis,
+            CHECK_NOTHROW(syncro.cycsyn_spectrum(gmin, gmax_actual, spline_eldis, acc_eldis,
                                                  spline_deriv, acc_deriv));
         }
 
@@ -233,8 +227,8 @@ TEST_CASE("Inverse Compton scattering") {
         gsl_interp_accel *acc_eldis = gsl_interp_accel_alloc();
         gsl_spline *spline_eldis = gsl_spline_alloc(gsl_interp_steffen, 100);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma().data(),
-                        electrons.get_gdens().data(), 100);
+        gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
+                        100);
 
         SUBCASE("Basic Compton scattering") {
             double radius = 1e15;    // cm
@@ -245,14 +239,13 @@ TEST_CASE("Inverse Compton scattering") {
             compton.set_tau(1e-3, temp_kev);
 
             // Use disk as seed photon field
-            compton.shsdisk_seed(disk.get_energy(), disk.tin(), disk.rin(),
-                                 disk.rin() * 100, disk.hdisk(), 0.0);
+            compton.shsdisk_seed(disk.get_energy(), disk.tin(), disk.rin(), disk.rin() * 100,
+                                 disk.hdisk(), 0.0);
 
             double gmin = electrons.get_gamma()[0];
             double gmax = electrons.get_gamma()[99];
 
-            CHECK_NOTHROW(
-                compton.compton_spectrum(gmin, gmax, spline_eldis, acc_eldis));
+            CHECK_NOTHROW(compton.compton_spectrum(gmin, gmax, spline_eldis, acc_eldis));
 
             CHECK(!compton.get_energy().empty());
             CHECK(!compton.get_nphot().empty());
@@ -265,14 +258,13 @@ TEST_CASE("Inverse Compton scattering") {
             compton.set_tau(0.1, temp_kev);    // Higher optical depth
             compton.set_niter(5);              // Multiple scatterings
 
-            compton.shsdisk_seed(disk.get_energy(), disk.tin(), disk.rin(),
-                                 disk.rin() * 100, disk.hdisk(), 0.0);
+            compton.shsdisk_seed(disk.get_energy(), disk.tin(), disk.rin(), disk.rin() * 100,
+                                 disk.hdisk(), 0.0);
 
             double gmin = electrons.get_gamma()[0];
             double gmax = electrons.get_gamma()[99];
 
-            CHECK_NOTHROW(
-                compton.compton_spectrum(gmin, gmax, spline_eldis, acc_eldis));
+            CHECK_NOTHROW(compton.compton_spectrum(gmin, gmax, spline_eldis, acc_eldis));
         }
 
         // Cleanup
@@ -306,16 +298,15 @@ TEST_CASE("Inverse Compton scattering") {
         gsl_interp_accel *acc_deriv = gsl_interp_accel_alloc();
         gsl_spline *spline_deriv = gsl_spline_alloc(gsl_interp_steffen, 100);
 
-        gsl_spline_init(spline_eldis, electrons.get_gamma().data(),
-                        electrons.get_gdens().data(), 100);
+        gsl_spline_init(spline_eldis, electrons.get_gamma().data(), electrons.get_gdens().data(),
+                        100);
         gsl_spline_init(spline_deriv, electrons.get_gamma().data(),
                         electrons.get_gdens_diff().data(), 100);
 
         double gmin = electrons.get_gamma()[0];
         double gmax_actual = electrons.get_gamma()[99];
 
-        syncro.cycsyn_spectrum(gmin, gmax_actual, spline_eldis, acc_eldis,
-                               spline_deriv, acc_deriv);
+        syncro.cycsyn_spectrum(gmin, gmax_actual, spline_eldis, acc_eldis, spline_deriv, acc_deriv);
 
         // Now set up SSC using synchrotron photons as seed
         ssc.set_frequency(1e20, 1e28);
@@ -325,8 +316,7 @@ TEST_CASE("Inverse Compton scattering") {
 
         ssc.cyclosyn_seed(syncro.get_energy(), syncro.get_nphot());
 
-        CHECK_NOTHROW(
-            ssc.compton_spectrum(gmin, gmax_actual, spline_eldis, acc_eldis));
+        CHECK_NOTHROW(ssc.compton_spectrum(gmin, gmax_actual, spline_eldis, acc_eldis));
 
         // Cleanup
         gsl_spline_free(spline_eldis);
@@ -351,8 +341,8 @@ TEST_CASE("Radiation consistency checks") {
         CHECK(total_lum > 0.0);
 
         // Stefan-Boltzmann check (approximately)
-        double expected_lum = 4.0 * karcst::pi * pow(1e10, 2.0) *
-                              karcst::sbconst * pow(5000.0, 4.0);
+        double expected_lum =
+            4.0 * karcst::pi * pow(1e10, 2.0) * karcst::sbconst * pow(5000.0, 4.0);
 
         // Should be within reasonable range (integration limits matter)
         CHECK(total_lum / expected_lum > 0.01);


### PR DESCRIPTION
This is somewhat pedantic, but type conversion have caused problems in the past. Making them explicit hopefully shows clearer where such potential problems are.

Nearly all type conversions are from size_t to double; as long as size_t is reasonably small (which it is), the precision will be conserved.

A few variables and a getter function needed to get their type changed to size_t as well.